### PR TITLE
fix: use thumbnail source for images to fix image duplication issue

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -148,9 +148,10 @@ export const snapsave = async (url: string, options?: SnapSaveDownloaderOptions)
       $("div.download-items").each((_, el) => {
         const itemThumbnail = $(el).find("div.download-items__thumb > img").attr("src");
         const itemBtn = $(el).find("div.download-items__btn");
-        const url = itemBtn.find("a").attr("href");
+        const downloadUrl = itemBtn.find("a").attr("href");
         const spanText = itemBtn.find("span").text().trim();
         const type = spanText === "Download Photo" ? "image" : "video";
+        const url = type === "image" ? itemThumbnail : downloadUrl;
         media.push({
           url,
           ...type === "video" ? {


### PR DESCRIPTION
Fixes a bug where images where repeated incorrectly for a post. Thumbnails are also seemingly the same size as the images themselves, so it works.